### PR TITLE
Patch from René

### DIFF
--- a/src/formatter.tcl
+++ b/src/formatter.tcl
@@ -566,19 +566,20 @@ oo::class create ruff::formatter::Formatter {
             }
         }
 
-        # Gather links for procs
+        # Gather links for procs without leading ::
         foreach proc_name [dict keys [dict get $ns_content procs]] {
             fqn! $proc_name
             ns_member! $ns $proc_name
-            my CollectSymbolReference $ns $proc_name
+            my CollectSymbolReference $ns [string trimleft $proc_name :]
         }
 
-        # Finally gather links for classes and methods
+        # Finally gather links for classes and methods without leading ::
         # A class name is also treated as a namespace component
         # although that is not strictly true.
         foreach {class_name class_info} [dict get $ns_content classes] {
             ns_member! $ns $class_name
-            my CollectSymbolReference $ns $class_name
+	    set class_ref [string trimleft $class_name :]
+            my CollectSymbolReference $ns $class_ref
             set method_info_list [concat [dict get $class_info methods] [dict get $class_info forwards]]
             foreach name {constructor destructor} {
                 if {[dict exists $class_info $name]} {
@@ -586,14 +587,10 @@ oo::class create ruff::formatter::Formatter {
                 }
             }
             foreach method_info $method_info_list {
-                # The class name is the scope for methods. Because of how
-                # the link target lookup works, we use the namespace
-                # operator to separate the class from method. We also
-                # store it a second time using the "." separator as that
-                # is how they are sometimes referenced.
+                # The class name is the scope for methods.
+                # We store and reference methods as <classname>.<methodname>.
                 set method_name [dict get $method_info name]
-                set ref [my CollectSymbolReference $ns ${class_name}::${method_name}]
-                my CollectSymbolReference $ns ${class_name}.${method_name} $ref
+                my CollectSymbolReference $ns ${class_ref}.${method_name}
             }
         }
     }
@@ -687,8 +684,9 @@ oo::class create ruff::formatter::Formatter {
         set display_name [trim_namespace $proc_name $hidenamespace]
 
         if {$proctype eq "method"} {
+            # Scope is class and fqn is <classname>.<methodname>.
             set scope $class; # Scope is name of class
-            set fqn   ${class}::$proc_name
+            set fqn   ${class}.$proc_name
         } else {
             set scope [namespace qualifiers $name]
             set fqn   $proc_name
@@ -903,6 +901,7 @@ oo::class create ruff::formatter::Formatter {
                 if {$referenced_class eq "::oo::configuresupport::configurable"} {
                     lappend method_summaries [list term $referenced_class.$method_name definition [list "Configure properties. See [markup_reference $referenced_class]."]]
                 } else {
+		    set referenced_class [string trimleft $referenced_class :]
                     lappend method_summaries [list term $referenced_class.$method_name definition [list "Inherited from [markup_reference $referenced_class]."]]
                 }
             }
@@ -974,7 +973,7 @@ oo::class create ruff::formatter::Formatter {
             # Creates locals for all the classinfo keys listed above.
         }
         my AddProgramElementHeading class $fqn
-        set scope $fqn
+        set scope [string trimleft $fqn :]
         if {[info exists preamble]} {
             my AddParagraphs $preamble $scope
         }
@@ -983,13 +982,15 @@ oo::class create ruff::formatter::Formatter {
             # The method names need to be escaped and linked.
             my AddDefinitions [lmap definition $method_summaries {
                 set term [dict get $definition term]
-                # TBD - The resolution currently only searches the namespace
-                # hierarchy, not the class hierarchy so methods defined
-                # in superclasses/mixins etc. will not be found. So
-                # those we just mark as code.
-                if {[my ResolvableReference? $term $scope dontcare]} {
-                    dict set definition term [markup_reference_to_method $term]
+               # Methods references as <classname>.<methodname> without leading ::.
+                if {[my ResolvableReference? $scope.$term {} dontcare]} {
+                    # own class method
+                    dict set definition term "\[$term\]\[$term\]"
+                } elseif {[my ResolvableReference? $term {} dontcare]} {
+                    # base class method
+                    dict set definition term "\[$term\]\[$term\]"
                 } elseif {[is_builtin $term]} {
+                    # ???
                     dict set definition term [markup_reference $term]
                 } else {
                     dict set definition term [markup_code $term]
@@ -1039,7 +1040,10 @@ oo::class create ruff::formatter::Formatter {
         }
         foreach var {superclasses mixins subclasses filters} {
             if {[info exists $var]} {
-                my AddReferences [set $var] $scope [string totitle $var]
+                # Add references without leading ::.
+		        set l {}
+		        foreach v [set $var] {lappend l [string trimleft $v :]}
+		        my AddReferences $l $scope [string totitle $var]
             }
         }
         if {[info exists constructor]} {
@@ -1207,6 +1211,7 @@ oo::class create ruff::formatter::Formatter {
                 # Add an anchor for actual namespace as well
                 my AddAnchor [my Anchor $ns]
             }
+            my AddAnchor [my Anchor $ns]
             my AddHeading 1 $ns_heading ""
 
             # Print the preamble for this namespace

--- a/src/formatter.tcl
+++ b/src/formatter.tcl
@@ -501,6 +501,7 @@ oo::class create ruff::formatter::Formatter {
         # but only if lookup value is not fully qualified.
 
         if {![my Reference? $lookup ref] && ! [string match ::* $lookup]} {
+            set scope [string trimleft $scope]
             while {$scope ne "" && ![info exists ref]} {
                 # Check class (.) and namespace scope (::)
                 if {[my Reference? ${scope}.$lookup ref]} {

--- a/src/formatter_asciidoctor.tcl
+++ b/src/formatter_asciidoctor.tcl
@@ -116,14 +116,14 @@ oo::class create ruff::formatter::Asciidoctor {
     }
 
     method AddProgramElementHeading {type fqn {tooltip {}} {synopsis {}}} {
-        # Adds heading for a program element like procedure, class or method.
+        # Adds heading without leading :: for a program element like procedure, class or method.
         #  type - One of `proc`, `class` or `method`
         #  fqn - Fully qualified name of element.
         #  tooltip - The tooltip lines, if any (not used in Asciidoctor).
 
         set level    [dict get $HeaderLevels $type]
-        set ns       [namespace qualifiers $fqn]
-        set anchor   [my MakeAsciidocId $fqn]
+        set ns       [namespace qualifiers [string trimleft $fqn :]]
+        set anchor   [my MakeAsciidocId [string trimleft $fqn:]]
         set exported_anchor [make_exported_id $fqn]
 
         set linkinfo [dict create tag h$level href "#$anchor"]

--- a/src/formatter_html.tcl
+++ b/src/formatter_html.tcl
@@ -71,7 +71,7 @@ oo::class create ruff::formatter::Html {
 
     method SymbolReference {ns symbol} {
         # Implements the [Formatter.SymbolReference] method for HTML.
-        set ref [ns_file_base $ns]
+	    set ref [ns_file_base $ns]
         # Reference to the global namespace is to the file itself.
         if {$ns eq "::" && $symbol eq ""} {
             return $ref
@@ -277,7 +277,7 @@ oo::class create ruff::formatter::Html {
     }
 
     method AddProgramElementHeading {type fqn {tooltip {}} {synopsis {}}} {
-        # Adds heading for a program element like procedure, class or method.
+        # Adds heading without leading :: for a program element like procedure, class or method.
         #  type - One of `proc`, `class` or `method`
         #  fqn - Fully qualified name of element.
         #  tooltip - The tooltip lines, if any, to be displayed in navigation pane.
@@ -288,9 +288,18 @@ oo::class create ruff::formatter::Html {
 
         set level    [dict get $HeaderLevels $type]
         set ns       [namespace qualifiers $fqn]
-        set anchor   [my Anchor $fqn]
-        set href     [my SymbolReference $ns $fqn]
-        set linkinfo [dict create level $level href $href ns $ns]
+        set anchor   [my Anchor [string trimleft $fqn :]]
+        set href     [my SymbolReference $ns [string trimleft $fqn :]]
+        set name     [namespace tail $fqn]
+        set scope    $ns
+	    if {$type eq {method}} {
+            # use fqn as <classname>.<methodname>
+	        if {[set i [string first . $name]] != -1} {
+		        set name [string range $name [incr i] end]
+                set scope [string range $fqn 2 end-[expr {[string length $name]+1}]]
+	        }
+        }
+        set linkinfo [dict create level $level href $href ns $scope]
 
         # Construct tooltip from synopsis and tooltip
         if {[llength $synopsis]} {
@@ -302,14 +311,16 @@ oo::class create ruff::formatter::Html {
         if {[info exists tip]} {
             dict set linkinfo tip $tip
         }
-
-        set name [namespace tail $fqn]
         dict set linkinfo label $name
         dict set NavigationLinks $anchor [dict create LinkInfo $linkinfo Type $type]
         dict set GlobalIndex $anchor $linkinfo
-        if {[string length $ns]} {
-            set ns_link [my FormatInline [markup_reference $ns]]
-            set heading "<a name='$anchor'>[my Escape $name]</a><span class='ns_scope'> \[${ns_link}\]</span>"
+        if {[string length $scope]} {
+            if {[my Reference? $scope ref]} {
+                set heading "<a name='$anchor'>[my Escape $name]</a><a href='[dict get $ref ref]'> [my Escape $scope]</a>"
+	        } else {
+                set ns_link [my FormatInline [markup_reference $scope]]
+                set heading "<a name='$anchor'>[my Escape $name]</a><span class='ns_scope'> \[${ns_link}\]</span>"
+	        }
         } else {
             set heading "<a name='$anchor'>[my Escape $fqn]</a>"
         }

--- a/src/formatter_markdown.tcl
+++ b/src/formatter_markdown.tcl
@@ -123,7 +123,7 @@ oo::class create ruff::formatter::Markdown {
     }
 
     method AddProgramElementHeading {type fqn {tooltip {}} {synopsis {}}} {
-        # Adds heading for a program element like procedure, class or method.
+        # Adds heading without leading :: for a program element like procedure, class or method.
         #  type - One of `proc`, `class` or `method`
         #  fqn - Fully qualified name of element.
         #  tooltip - The tooltip lines, if any, to be displayed in the navigation pane.
@@ -132,7 +132,7 @@ oo::class create ruff::formatter::Markdown {
         set level    [dict get $HeaderLevels $type]
         set atx      [string repeat # $level]
         set ns       [namespace qualifiers $fqn]
-        set anchor   [my Anchor $fqn]
+        set anchor   [my Anchor [string trimleft $fqn :]]
         set linkinfo [dict create tag h$level href "#$anchor"]
         if {[llength $tooltip]} {
             set tip "[my FormatInline [string trim [join $tooltip { }]] $ns]\n"

--- a/src/formatter_sphinx.tcl
+++ b/src/formatter_sphinx.tcl
@@ -114,7 +114,7 @@ oo::class create ruff::formatter::Sphinx {
     }
 
     method AddProgramElementHeading {type fqn {tooltip {}} {synopsis {}}} {
-        # Adds heading for a program element like procedure, class or method.
+        # Adds heading without leading :: for a program element like procedure, class or method.
         #  type - One of `proc`, `class` or `method`
         #  fqn - Fully qualified name of element.
         #  tooltip - The tooltip lines, if any, to be displayed in the
@@ -123,8 +123,8 @@ oo::class create ruff::formatter::Sphinx {
 
         set level    [dict get $HeaderLevels $type]
         set ns       [namespace qualifiers $fqn]
-        set anchor   [my MakeSphinxId $fqn]
-        set exported_anchor [make_exported_id $fqn]
+        set anchor   [my MakeSphinxId [string trimleft $fqn :]]
+        set exported_anchor [make_exported_id [string trimleft $fqn :]]
 
         # Track anchors for navigation
         set linkinfo [dict create tag h$level href "#$anchor"]

--- a/src/ruff.tcl
+++ b/src/ruff.tcl
@@ -1241,9 +1241,9 @@ proc ruff::private::make_exported_id {args} {
 }
 
 
-proc ruff::private::ns_file_base {ns_or_class {ext {}}} {
+proc ruff::private::ns_file_base {ns {ext {}}} {
     # Returns the file name to use for documenting namespace $ns.
-    # ns_or_class - the namespace or class for the file
+    # ns - the namespace for the file
     # ext - if non-empty, this is used as the file extension.
     #  It should include the initial period.
     variable output_file_base
@@ -1251,13 +1251,6 @@ proc ruff::private::ns_file_base {ns_or_class {ext {}}} {
     variable ns_file_base_cache
     variable ProgramOptions
 
-    # Methods can also be represented as Class::method so this is a
-    # hack to get the real namespace and not the class name
-    if {[info object isa class $ns_or_class]} {
-        set ns [namespace qualifiers $ns_or_class]
-    } else {
-        set ns $ns_or_class
-    }
     if {![info exists ns_file_base_cache($ns)]} {
         if {$ProgramOptions(-pagesplit) eq "none" || $ns eq "::"} {
             set fn "$output_file_base$output_file_ext"
@@ -3630,7 +3623,6 @@ proc ruff::document {namespaces args} {
                                -onlyexports $opts(-onlyexports) \
                                -include $opts(-include) \
                                -includeprivate $opts(-includeprivate)]
-
     set docs [$formatter generate_document \
                   $classprocinfodict \
                   -include $opts(-include) \


### PR DESCRIPTION
The proposal is to distinguish between namespaces (starting with :: ) and
Commands (class, proc, method) starting without ::. So you can refer to a namespace "::A" and a proc "A" or a class "A" and a method "A.a". A nameclash can only occur if you use A.a as a proc.

> Currently, within a namespace ::A::B::C the reference [D::foo] will refer to program element foo (proc or class) within namespace ::A::B::C::D. Would that stay the same in your scheme or become a reference to ::D::foo?

Oh, I did not know this. Where and how did you do this check?
With my proposal you would have to use [::A::B::C::foo] for namespaces and [A::B::C::foo] for procs or classes. May be it could be changed to look first in the current namespace and afterwards in the global namespace.

> By the way, you can already reference methods using . notation (Class.method)

This will stay the same. But you have to use the Class part without leading ::.
